### PR TITLE
Calculate the API URL based on `window.location`

### DIFF
--- a/src/constants/dataServer.ts
+++ b/src/constants/dataServer.ts
@@ -2,7 +2,7 @@ const getDataServerUrl = (): string => {
   // If it looks like the app is running in a non-production deployment, treat
   // it like a dev/testing deployment and expect the data server to be running
   // on the same host at the default port.
-  if (window.location.port == "8080") {
+  if (window.location.port === "8080") {
     return `${window.location.protocol}//${window.location.hostname}`;
   }
 

--- a/src/constants/dataServer.ts
+++ b/src/constants/dataServer.ts
@@ -1,4 +1,15 @@
-export const dataServerUrl = 'https://nsidc.org/api/snow-today'
+const getDataServerUrl = (): string => {
+  // If it looks like the app is running in a non-production deployment, treat
+  // it like a dev/testing deployment and expect the data server to be running
+  // on the same host at the default port.
+  if (window.location.port == "8080") {
+    return `${window.location.protocol}//${window.location.hostname}`;
+  }
+
+  return 'https://nsidc.org/api/snow-today';
+}
+
+export const dataServerUrl = getDataServerUrl();
 
 // Information about regions:
 export const regionsIndexUrl = `${dataServerUrl}/regions.json`;


### PR DESCRIPTION
This is a workaround for #36 . It doesn't make the API URL configurable, but adds some assumptions and calculates the URL dynamically.

I don't like this implementation, but I don't have such a great handle on how to implement #36 the right way yet.