### PR TITLE
Use timezone aware dates for mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "serve": "webpack serve",
     "lint": "eslint src --ext .ts --ext .tsx",
     "compile": "tsc --project tsconfig.json",
-    "test": "node jest/scripts/test.js"
+    "test": "node jest/scripts/test.js",
+    "test:debug": "node inspect jest/scripts/test.js"
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.7",

--- a/src/util/__tests__/waterYear.ts
+++ b/src/util/__tests__/waterYear.ts
@@ -8,24 +8,27 @@ import {
 } from '../waterYear';
 
 
+const jan1TestDate = new Date(2022, 0, 1) 
+const oct5TestDate = new Date(2022, 9, 5);
+
 test('Calculates water year day 1 in correct calendar year', () => {
   // Since the calendar year and water year are not synced, expect WYD1 to be
   // last year if today is before the water year start day.
-  MockDate.set('2022-01-01');
+  MockDate.set(jan1TestDate);
   // We have to clear the cache to support different mocked dates:
   waterYearDay1.cache.clear!();
   expect(getYear(waterYearDay1())).toEqual(2021);
 });
 
 test('Calculates October 5th as day 5 of the water year', () => {
-  MockDate.set('2022-10-05');
+  MockDate.set(oct5TestDate);
   waterYearDay1.cache.clear!();
   currentDowy.cache.clear!();
   expect(currentDowy()).toEqual(5);
 });
 
 test('Calculates Jan 1st as day 93 of the water year', () => {
-  MockDate.set('2022-01-01');
+  MockDate.set(jan1TestDate);
   waterYearDay1.cache.clear!();
   currentDowy.cache.clear!();
   expect(currentDowy()).toEqual(93);
@@ -35,7 +38,7 @@ test('Calculates DOWY 93 as Jan 1st', () => {
   // Mock the date because the "current" water year will change over time in a
   // way that doesn't sync with calendar year, so we can't use the current year
   // in the test.
-  MockDate.set('2022-01-01!');
+  MockDate.set(jan1TestDate);
 
   waterYearDay1.cache.clear!();
   currentDowy.cache.clear!();


### PR DESCRIPTION
Our tests were passing in GitHub Actions but not locally, which tipped me off that timezone might be an issue. In GHA, I think the runner just so happens to be using UTC as the local time zone, and so the mocks happened to work out OK.