### PR TITLE
Adding SWE Units to the point popups on the map

### DIFF
--- a/src/components/MainWindow/SlippyMap/Tooltip.tsx
+++ b/src/components/MainWindow/SlippyMap/Tooltip.tsx
@@ -8,14 +8,15 @@ import {SwePointForOverlay} from '@src/types/swe';
 
 interface ISlippyMapTooltipProps {
   features: Array<Feature>;
+  unit: string | null | undefined;
   onClose: () => void;
 }
 
 
 const SlippyMapTooltip: React.FC<ISlippyMapTooltipProps> = (props) => {
 
-  const featuresHTML = (features: Array<Feature>): JSX.Element | null => {
-    const f = features[0]
+  const featuresHTML = (props: ISlippyMapTooltipProps): JSX.Element | null => {
+    const f = props.features[0]
     if (f === undefined) {
       return null;
     }
@@ -43,7 +44,7 @@ const SlippyMapTooltip: React.FC<ISlippyMapTooltipProps> = (props) => {
           </div>
 
           <div className="feature-attribute">
-            Value: {featureData['measurement_inches']}
+            Value: {featureData['measurement_inches']} {props.unit && props.unit.includes("Percentage") ? "%" : "cm"}
           </div>
 
         </div>
@@ -51,7 +52,7 @@ const SlippyMapTooltip: React.FC<ISlippyMapTooltipProps> = (props) => {
     );
   };
 
-  return featuresHTML(props.features);
+  return featuresHTML(props);
 }
 
 export default SlippyMapTooltip;

--- a/src/components/MainWindow/SlippyMap/Tooltip.tsx
+++ b/src/components/MainWindow/SlippyMap/Tooltip.tsx
@@ -8,7 +8,7 @@ import {SwePointForOverlay} from '@src/types/swe';
 
 interface ISlippyMapTooltipProps {
   features: Array<Feature>;
-  unit: string | null | undefined;
+  unit: string | undefined;
   onClose: () => void;
 }
 
@@ -44,7 +44,7 @@ const SlippyMapTooltip: React.FC<ISlippyMapTooltipProps> = (props) => {
           </div>
 
           <div className="feature-attribute">
-            Value: {featureData['measurement_inches']} {props.unit && props.unit.includes("Percentage") ? "%" : "cm"}
+            Value: {featureData['measurement_inches']} {props.unit}
           </div>
 
         </div>

--- a/src/components/MainWindow/SlippyMap/index.tsx
+++ b/src/components/MainWindow/SlippyMap/index.tsx
@@ -201,7 +201,7 @@ const SlippyMap: React.FC<ISlippyMapProps> = (props) => {
         <div ref={overlayElement}>
           <SlippyMapTooltip
             features={selectedFeatures}
-            unit={selectedSweVariable?.longName}
+            unit={selectedSweVariable?.unit}
             onClose={handleMapTipClose} />
         </div>
 

--- a/src/components/MainWindow/SlippyMap/index.tsx
+++ b/src/components/MainWindow/SlippyMap/index.tsx
@@ -201,6 +201,7 @@ const SlippyMap: React.FC<ISlippyMapProps> = (props) => {
         <div ref={overlayElement}>
           <SlippyMapTooltip
             features={selectedFeatures}
+            unit={selectedSweVariable?.longName}
             onClose={handleMapTipClose} />
         </div>
 

--- a/src/types/query/variables.ts
+++ b/src/types/query/variables.ts
@@ -51,6 +51,7 @@ export interface ISweVariable {
   noDataValue: number;
   colormapId:  number;
   transparentZero: boolean;
+  unit: string;
 }
 
 export interface ISweVariableIndex {


### PR DESCRIPTION
From Snow Today GitHub Project Issue: [#68](https://github.com/nsidc/snow-today-webapp-server/issues/68)

I passed in the `longName` of the `selectedSweVariable` as that was the best option I could find in the SlippyMap index.js. The only variable from `selectedSweVariable` that I could use to differentiate was the `longName`, so to update the unit, I check for a .includes("Percentage") in ToolTip.tsx. To accomplish this in TypeScript, I had to add a new type to the input of ToolTip.tsx and changed part of the logic of `featuresHTML(features)` -> `featuresHTML(props)`, to allow the use of `props.unit` inside the function.
I don't like this approach because it requires the name of the SWE variable to have 'Percentage' in the title, but it was the only way I found to consistently change the units.